### PR TITLE
Update depcheck to support ES6 import syntax.

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "homepage": "https://github.com/mcasimir/gulp-depcheck#readme",
   "dependencies": {
-    "depcheck": "^0.4.7",
+    "depcheck": "^0.6.4",
     "es6-promise": "^3.0.2",
     "gulp-util": "^3.0.7",
     "lodash": "^3.10.1"


### PR DESCRIPTION
Hi @mcasimir :-)

Thanks for your great work with `gulp-depcheck`. I am using it for quite a while now, and everything works perfectly so far :-)

Today, I stumbled upon a module which uses ES6 `import` syntax, and it didn't work out: `depcheck` reported a syntax error, and when I had a look at your `package.json` file I realized that one only needs to update `depcheck` to the latest version to make things work.

Hence, please find this PR. I hope that you like it (although it's just a few characters ;-)).

Have a nice day,

Golo
