### PR TITLE
Add rootDir option so that the depcheck can be performed somewhere other than the cwd.

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ First you need to add gulp-depcheck to your project.
 const depcheck = require('gulp-depcheck');
 ```
 
-Then, you can use the `depcheck` funtion to define Gulp tasks.
+Then, you can use the `depcheck` function to define Gulp tasks.
 
 ```javascript
 gulp.task('depcheck', depcheck());
@@ -27,6 +27,14 @@ You may want to exclude some directories from being checked, e.g. the `test` dir
 ```javascript
 gulp.task('depcheck', depcheck({
   ignoreDirs: [ 'test' ]
+}));
+```
+
+By default the depcheck will be performed on the current working directory.  To specify a different directory use the `rootDir` option.
+
+```javascript
+gulp.task('depcheck', depcheck({
+  rootDir: '/path/to/your/project'
 }));
 ```
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ gulp.task('depcheck', depcheck({
 }));
 ```
 
-By default the depcheck will be performed on the current working directory.  To specify a different directory use the `rootDir` option.
+By default the dependency check will be performed on the current working directory. To specify a different directory use the `rootDir` option.
 
 ```javascript
 gulp.task('depcheck', depcheck({
@@ -83,7 +83,7 @@ The MIT License (MIT)
 
 Copyright (c) 2015-2016 Maurizio Casimirri
 
-Copyright (c) 2016 the native web
+Copyright (c) 2016-2017 the native web
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/lib/gulpDepcheck.js
+++ b/lib/gulpDepcheck.js
@@ -17,6 +17,8 @@ const gulpDepcheck = function (options) {
   /* eslint-disable global-require */
   const depcheck = options.depcheck || require('depcheck');
   /* eslint-enable global-require */
+  
+  const rootDir = options.rootDir || process.cwd();
 
   const ignoreMissing = options.missing === false,
         ignoreUnusedDependencies = options.dependencies === false,
@@ -34,12 +36,13 @@ const gulpDepcheck = function (options) {
     'devDependencies',
     'invalidFiles',
     'invalidDirs',
-    'missing'
+    'missing',
+    'rootDir'
   );
 
   return function () {
     return new Promise((resolve, reject) => {
-      depcheck(process.cwd(), options, unused => {
+      depcheck(rootDir, options, unused => {
         const missing = ignoreMissing ? [] : Object.keys(unused.missing || {}),
               unusedDependencies = ignoreUnusedDependencies ? [] : unused.dependencies || [],
               unusedDevDependencies = ignoreUnusedDevDependencies ? [] : unused.devDependencies || [];

--- a/test/units/gulpDepcheckTests.js
+++ b/test/units/gulpDepcheckTests.js
@@ -5,10 +5,29 @@ const assert = require('assertthat');
 const depcheck = require('../../lib/gulpDepcheck');
 
 suite('gulpDepcheck', () => {
-  test('calls depcheck on the current working directory.', done => {
+  test('calls depcheck on the current working directory by default.', done => {
     depcheck({
       depcheck (path) {
         assert.that(path).is.equalTo(process.cwd());
+        done();
+      }
+    })();
+  });
+
+  test('calls depcheck with the specified root directory.', done => {
+    depcheck({
+      depcheck (path) {
+        assert.that(path).is.equalTo('/path/to/project');
+        done();
+      },
+      rootDir: '/path/to/project'
+    })();
+  });
+
+  test('does not pass the rootDir option to depcheck.', done => {
+    depcheck({
+      depcheck (path, options) {
+        assert.that(options.rootDir).is.undefined();
         done();
       }
     })();


### PR DESCRIPTION
Solves issue #4.

An alternative to a new option is adding an optional first parameter, which would make it possible to call gulp-depcheck like the original depcheck but it does make the interface a bit more messy.