### PR TITLE
Exporting the depcheck ‘special’ property so it can be used in the op…

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,17 @@ gulp.task('depcheck', depcheck({
 }));
 ```
 
+Access [special depcheck parsers](https://github.com/depcheck/depcheck#special) via the `special` property. Pass them as options to recognize the dependencies outside of the normal syntax.
+
+```javascript
+gulp.task('depcheck', depcheck({
+  specials : [
+    depcheck.special.babel,
+    depcheck.special.webpack
+  ]
+}));
+```
+
 ### Configuring the report
 
 By default, gulp-depcheck fails on any issue it finds. From time to time you might want to adjust this, e.g. to allow unused packages in the `devDependencies` section of your `package.json` file, or to only report packages that are missing from your `package.json` file.
@@ -60,6 +71,21 @@ Moreover, gulp-depcheck supports all options of [depcheck](https://www.npmjs.com
 If you want to configure the version of depcheck to use explicitly provide a reference to it using the `depcheck` property.
 
 Additionally, you are allowed to set a default value for the directories to ignore. For that use the `ignoreDirsDefault` property and hand over the names of the directories to ignore as an array. The default value is `['node_modules', 'bower_components']`.
+
+Note that if you use a custom version of depcheck you must pass any special parsers explicitly.
+
+```javascript
+const depcheck = require('gulp-depcheck'),
+      myCustomDepcheck = require('depcheck');
+
+gulp.task('depcheck', depcheck({
+    depcheck : myCustomDepcheck,
+    specials : [
+        myCustomDepcheck.special.babel,
+        myCustomDepcheck.special.webpack
+    ]
+}));
+```
 
 ## Running the build
 

--- a/lib/gulpDepcheck.js
+++ b/lib/gulpDepcheck.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const _ = require('lodash'),
-      dc = require('depcheck'),
+      depcheck = require('depcheck'),
       gutil = require('gulp-util');
 
 const PluginError = gutil.PluginError;
@@ -15,7 +15,7 @@ const pluginError = function (message) {
 const gulpDepcheck = function (options) {
   options = options || {};
 
-  const depcheck = options.hasOwnProperty('depcheck') ? options.depcheck : dc;
+  const depcheckInstance = options.hasOwnProperty('depcheck') ? options.depcheck : depcheck;
 
   const ignoreMissing = options.missing === false,
         ignoreUnusedDependencies = options.dependencies === false,
@@ -38,7 +38,7 @@ const gulpDepcheck = function (options) {
 
   return function () {
     return new Promise((resolve, reject) => {
-      depcheck(process.cwd(), options, unused => {
+      depcheckInstance(process.cwd(), options, unused => {
         const missing = ignoreMissing ? [] : Object.keys(unused.missing || {}),
               unusedDependencies = ignoreUnusedDependencies ? [] : unused.dependencies || [],
               unusedDevDependencies = ignoreUnusedDevDependencies ? [] : unused.devDependencies || [];
@@ -70,6 +70,6 @@ const gulpDepcheck = function (options) {
   };
 };
 
-gulpDepcheck.special = dc.special;
+gulpDepcheck.special = depcheck.special;
 
 module.exports = gulpDepcheck;

--- a/lib/gulpDepcheck.js
+++ b/lib/gulpDepcheck.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const _ = require('lodash'),
+      dc = require('depcheck'),
       gutil = require('gulp-util');
 
 const PluginError = gutil.PluginError;
@@ -14,9 +15,7 @@ const pluginError = function (message) {
 const gulpDepcheck = function (options) {
   options = options || {};
 
-  /* eslint-disable global-require */
-  const depcheck = options.depcheck || require('depcheck');
-  /* eslint-enable global-require */
+  const depcheck = options.hasOwnProperty('depcheck') ? options.depcheck : dc;
 
   const ignoreMissing = options.missing === false,
         ignoreUnusedDependencies = options.dependencies === false,
@@ -70,5 +69,7 @@ const gulpDepcheck = function (options) {
     });
   };
 };
+
+gulpDepcheck.special = dc.special;
 
 module.exports = gulpDepcheck;

--- a/package.json
+++ b/package.json
@@ -10,6 +10,10 @@
     {
       "name": "Golo Roden",
       "email": "golo.roden@thenativeweb.io"
+    },
+    {
+      "name": "Eric Johnson",
+      "email": "edj.boston@gmail.com"
     }
   ],
   "main": "lib/gulpDepcheck.js",

--- a/test/units/gulpDepcheckTests.js
+++ b/test/units/gulpDepcheckTests.js
@@ -314,4 +314,10 @@ suite('gulpDepcheck', () => {
     }).is.not.throwing();
     done();
   });
+
+  test('returns a special property that is an object.', done => {
+    assert.that(depcheck.special).is.not.undefined();
+    assert.that(depcheck.special).is.ofType('object');
+    done();
+  });
 });


### PR DESCRIPTION
I added a `special` property to the gulp plugin that is a duplicate of the depcheck dependency inside the plugin itself. It allows you to bring in special parsers and pass them as options, like so:

```js
var gulpDepcheck = require('gulp-depcheck');

gulp.task('package', gulpDepcheck({
    ignoreMatches : [ 'bootstrap',  'jquery' ],
    specials : [
        gulpDepcheck.special.babel,
        gulpDepcheck.special['gulp-load-plugins']
    ]
}));
```

__Notes:__
1.) If someone passes their own version of depcheck as an option, it will not be used by the special property. But they can pass their own specials in like so:

```js
var depcheck = require('depcheck');
var gulpDepcheck = require('gulp-depcheck');

gulp.task('package', gulpDepcheck({
    depcheck : depcheck,
    ignoreMatches : [ 'bootstrap',  'jquery' ],
    specials : [
        depcheck.special.babel,
        depcheck.special['gulp-load-plugins']
    ]
}));
```

2.) I could not get your code to build on my machine:

```sh
[16:14:38] Starting '_license'...
[
  {
    package: 'has',
    version: '1.0.1',
    license: 'UNKNOWN'
  }
]
[16:14:39] '_license' errored after 112 ms
```
But it did lint at least.
